### PR TITLE
Ajoute un overlay de fin de manche

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import { ChatPanel } from './components/ChatPanel';
 import { Announcements } from './components/Announcements';
 import { Scores } from './components/Scores';
 import { GuessZone } from './components/GuessZone';
+import { RoundSummaryOverlay } from './components/RoundSummaryOverlay';
 
 export default function App() {
   const [roomCode, setRoomCode] = useState('');
@@ -24,10 +25,13 @@ export default function App() {
     scores,
     messages,
     announcements,
+    lastAuthor,
     joinRoom,
     startGame,
     submitGuess,
   } = useGameLogic(pseudo);
+
+  const overlayVisible = phase === 'Résultat' || phase === 'Transition';
 
   // Écran de connexion tant que non connecté
   if (!connected) {
@@ -44,7 +48,7 @@ export default function App() {
 
   // Vue principale de la partie
   return (
-    <div style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
+    <div style={{ padding: '2rem', fontFamily: 'sans-serif', position: 'relative' }}>
       <h1>Devine l'auteur</h1>
 
       <GameHeader
@@ -70,6 +74,12 @@ export default function App() {
         guessOptions={guessOptions}
         hasGuessed={hasGuessed}
         onGuess={submitGuess}
+      />
+
+      <RoundSummaryOverlay
+        visible={overlayVisible}
+        author={lastAuthor}
+        scores={scores}
       />
     </div>
   );

--- a/src/components/RoundSummaryOverlay.jsx
+++ b/src/components/RoundSummaryOverlay.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export function RoundSummaryOverlay({ visible, author, scores }) {
+  if (!visible) return null;
+
+  const ranking = Object.entries(scores)
+    .sort(([, a], [, b]) => b - a);
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal">
+        <h2>L'auteur était {author}</h2>
+        <h3>Classement</h3>
+        <ol style={{ textAlign: 'left' }}>
+          {ranking.map(([p, s]) => (
+            <li key={p}>{p}: {s}</li>
+          ))}
+        </ol>
+      </div>
+    </div>
+  );
+}
+

--- a/src/hooks/useGameLogic.js
+++ b/src/hooks/useGameLogic.js
@@ -160,6 +160,7 @@ export function useGameLogic(pseudo) {
     scores,
     messages,
     announcements,
+    lastAuthor,
     joinRoom,
     startGame,
     submitGuess,


### PR DESCRIPTION
## Summary
- ajoute un composant `RoundSummaryOverlay`
- affiche l'auteur et le classement à la fin d'une manche
- exporte `lastAuthor` depuis `useGameLogic`
- utilise l'overlay dans `App`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859255399688321bb8970344e55f1a7