### PR TITLE
Add host room configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,21 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Room parameters
+
+When the user is the host of a room, additional settings can be tuned before starting the game:
+
+- **Rounds** – slider between 5 and 50 (step of 5, default 10)
+- **Messages per round** – slider between 1 and 10
+- **Only GIFs** – toggle button
+
+Once configured, these values are sent with the `startGame` socket event. On the server side implement a listener:
+
+```js
+io.on('connection', (socket) => {
+  socket.on('startGame', ({ rounds, messagesPerRound, onlyGifs }) => {
+    // Start the game with the given settings
+  });
+});
+```

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,11 @@ import { RoundSummaryOverlay } from './components/RoundSummaryOverlay';
 export default function App() {
   const [roomCode, setRoomCode] = useState('');
   const [pseudo, setPseudo] = useState('');
+  const [roomParams, setRoomParams] = useState({
+    rounds: 10,
+    onlyGifs: false,
+    messagesPerRound: 1,
+  });
 
   const {
     connected,
@@ -57,7 +62,9 @@ export default function App() {
         timeLeft={timeLeft}
         isChef={isChef}
         gameStarted={gameStarted}
-        onStart={startGame}
+        roomParams={roomParams}
+        setRoomParams={setRoomParams}
+        onStart={() => startGame(roomParams)}
       />
 
       <div style={{ display: 'flex', gap: '2rem', marginTop: '1rem' }}>

--- a/src/components/GameHeader.jsx
+++ b/src/components/GameHeader.jsx
@@ -13,7 +13,9 @@ export function GameHeader({
   timeLeft,
   isChef,
   gameStarted,
-  onStart
+  onStart,
+  roomParams,
+  setRoomParams,
 }) {
   return (
     <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
@@ -27,7 +29,54 @@ export function GameHeader({
         )}
       </div>
       {isChef && !gameStarted && (
-        <button onClick={onStart}>Démarrer</button>
+        <>
+          <label>
+            Rounds: {roomParams.rounds}
+            <input
+              type="range"
+              min="5"
+              max="50"
+              step="5"
+              value={roomParams.rounds}
+              onChange={e =>
+                setRoomParams({
+                  ...roomParams,
+                  rounds: parseInt(e.target.value, 10),
+                })
+              }
+            />
+          </label>
+          <label>
+            Messages/round: {roomParams.messagesPerRound}
+            <input
+              type="range"
+              min="1"
+              max="10"
+              step="1"
+              value={roomParams.messagesPerRound}
+              onChange={e =>
+                setRoomParams({
+                  ...roomParams,
+                  messagesPerRound: parseInt(e.target.value, 10),
+                })
+              }
+            />
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+            <input
+              type="checkbox"
+              checked={roomParams.onlyGifs}
+              onChange={e =>
+                setRoomParams({
+                  ...roomParams,
+                  onlyGifs: e.target.checked,
+                })
+              }
+            />
+            Uniquement Gifs
+          </label>
+          <button onClick={onStart}>Démarrer</button>
+        </>
       )}
     </div>
   );

--- a/src/hooks/useGameLogic.js
+++ b/src/hooks/useGameLogic.js
@@ -138,8 +138,8 @@ export function useGameLogic(pseudo) {
     socket.emit('joinRoom', { roomCode, pseudo: p });
   }
 
-  function startGame() {
-    socket.emit('startGame');
+  function startGame(params = {}) {
+    socket.emit('startGame', params);
   }
 
   function submitGuess(guess) {


### PR DESCRIPTION
## Summary
- allow host to configure room (rounds, gif only, messages per round)
- send parameters with `startGame` socket event
- document expected server listener

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68594f0451448321b1e8df71d7b68e9b