### PR TITLE
Implement crown display for room host

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ export default function App() {
     connected,
     gameStarted,
     isChef,
+    chefName,
     roundNumber,
     phase,
     timeLeft,
@@ -76,7 +77,7 @@ export default function App() {
 
         <div style={{ flex: 1 }}>
           <Announcements announcements={announcements} />
-          <Scores scores={scores} />
+          <Scores scores={scores} chefName={chefName} />
         </div>
       </div>
 

--- a/src/components/Scores.jsx
+++ b/src/components/Scores.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 
-export function Scores({ scores }) {
+export function Scores({ scores, chefName }) {
   return (
     <div style={{ border: '1px solid #ccc', padding: '1rem' }}>
       <h3>Scores</h3>
       <ul>
-        {Object.entries(scores).map(([p, s]) => <li key={p}>{p}: {s}</li>)}
+        {Object.entries(scores).map(([p, s]) => (
+          <li key={p}>
+            {p === chefName ? '👑' : ''}{p}: {s}
+          </li>
+        ))}
       </ul>
     </div>
   );

--- a/src/hooks/useGameLogic.js
+++ b/src/hooks/useGameLogic.js
@@ -7,6 +7,7 @@ export function useGameLogic(pseudo) {
   const [connected, setConnected] = useState(false);
   const [gameStarted, setGameStarted] = useState(false);
   const [isChef, setIsChef] = useState(false);
+  const [chefName, setChefName] = useState('');
 
   // état de la manche
   const [roundNumber, setRoundNumber] = useState(0);
@@ -42,10 +43,12 @@ export function useGameLogic(pseudo) {
       setConnected(true);
       setGameStarted(gs);
       setIsChef(pseudo === chef);
+      setChefName(chef);
       setScores(Object.fromEntries(participants.map(p => [p, 0])));
       setAnnouncements([
-        `Participants : ${participants.join(', ')}`,
-        `Chef : ${chef}`
+        `Participants : ${participants
+          .map(p => (p === chef ? `👑${p}` : p))
+          .join(', ')}`
       ]);
     }
 
@@ -53,12 +56,14 @@ export function useGameLogic(pseudo) {
       setScores(prevScores => {
         const newScores = { ...prevScores, [newPseudo]: 0 };
         setAnnouncements([
-          `Participants : ${Object.keys(newScores).join(', ')}`,
-          `Chef : ${chef}`
+          `Participants : ${Object.keys(newScores)
+            .map(p => (p === chef ? `👑${p}` : p))
+            .join(', ')}`
         ]);
         return newScores;
       });
       setIsChef(pseudo === chef);
+      setChefName(chef);
     }
 
     // 2. Partie démarrée
@@ -171,6 +176,7 @@ export function useGameLogic(pseudo) {
     connected,
     gameStarted,
     isChef,
+    chefName,
     roundNumber,
     phase,
     timeLeft,


### PR DESCRIPTION
## Summary
- track chef's name in the game logic
- show a crown next to host in announcements and scores
- pass chef name to the Scores component

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68595ed24adc8321ac64cca414c2505a