### PR TITLE
Add game end actions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import { Announcements } from './components/Announcements';
 import { Scores } from './components/Scores';
 import { GuessZone } from './components/GuessZone';
 import { RoundSummaryOverlay } from './components/RoundSummaryOverlay';
+import { GameEndOverlay } from './components/GameEndOverlay';
 
 export default function App() {
   const [roomCode, setRoomCode] = useState('');
@@ -36,6 +37,9 @@ export default function App() {
     joinRoom,
     startGame,
     submitGuess,
+    restartLobby,
+    leaveRoom,
+    finalRanking,
   } = useGameLogic(pseudo);
 
   const overlayVisible = phase === 'Résultat' || phase === 'Transition';
@@ -91,6 +95,14 @@ export default function App() {
         visible={overlayVisible}
         author={lastAuthor}
         scores={scores}
+      />
+
+      <GameEndOverlay
+        visible={phase === 'Terminé'}
+        ranking={finalRanking}
+        isChef={isChef}
+        onRestart={restartLobby}
+        onQuit={leaveRoom}
       />
 
       {gameStarted && gameSettings && (

--- a/src/components/GameEndOverlay.jsx
+++ b/src/components/GameEndOverlay.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export function GameEndOverlay({ visible, ranking, isChef, onRestart, onQuit }) {
+  if (!visible) return null;
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal">
+        <h2>Partie terminée</h2>
+        <h3>Classement final</h3>
+        <ol style={{ textAlign: 'left' }}>
+          {ranking.map(r => (
+            <li key={r.pseudo}>{r.pseudo}: {r.score}</li>
+          ))}
+        </ol>
+        <div style={{ marginTop: '1rem' }}>
+          {isChef && <button onClick={onRestart}>Relancer</button>}
+          <button onClick={onQuit} style={{ marginLeft: isChef ? '0.5rem' : 0 }}>Quitter</button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show final ranking with restart & quit buttons
- store final ranking and add lobby restart logic in game hook
- add new overlay for end of game

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68595f946f38832198751422a56b26ad