### PR TITLE
Add confetti and guess markers

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,13 +29,11 @@
       }
 
       .confetti-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
+        position: fixed;
+        inset: 0;
         pointer-events: none;
         overflow: hidden;
+        z-index: 150;
       }
       .confetti-piece {
         position: absolute;

--- a/index.html
+++ b/index.html
@@ -27,6 +27,30 @@
         margin-top: 1rem;
         padding: 0.5rem 1rem;
       }
+
+      .confetti-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
+        overflow: hidden;
+      }
+      .confetti-piece {
+        position: absolute;
+        top: -10px;
+        width: 8px;
+        height: 8px;
+        opacity: 0.9;
+        animation-name: confetti-fall;
+        animation-timing-function: linear;
+      }
+      @keyframes confetti-fall {
+        to {
+          transform: translateY(100vh) rotate(720deg);
+        }
+      }
     </style>
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,7 @@ export default function App() {
     messages,
     announcements,
     lastAuthor,
+    lastProposals,
     gameSettings,
     currentRoom,
     joinRoom,
@@ -97,6 +98,7 @@ export default function App() {
         visible={overlayVisible}
         author={lastAuthor}
         scores={scores}
+        proposals={lastProposals}
       />
 
       <GameEndOverlay

--- a/src/components/Confetti.jsx
+++ b/src/components/Confetti.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-export function Confetti({ active }) {
+export function Confetti({ active, style }) {
   const [pieces, setPieces] = useState([]);
 
   useEffect(() => {
@@ -17,7 +17,7 @@ export function Confetti({ active }) {
   if (!active) return null;
 
   return (
-    <div className="confetti-container">
+    <div className="confetti-container" style={style}>
       {pieces.map((p, i) => (
         <div
           key={i}

--- a/src/components/Confetti.jsx
+++ b/src/components/Confetti.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+
+export function Confetti({ active }) {
+  const [pieces, setPieces] = useState([]);
+
+  useEffect(() => {
+    if (!active) return;
+    const newPieces = Array.from({ length: 40 }).map(() => ({
+      left: Math.random() * 100,
+      bg: `hsl(${Math.random() * 360},100%,50%)`,
+      delay: Math.random() * 0.5,
+      duration: 2 + Math.random() * 3,
+    }));
+    setPieces(newPieces);
+  }, [active]);
+
+  if (!active) return null;
+
+  return (
+    <div className="confetti-container">
+      {pieces.map((p, i) => (
+        <div
+          key={i}
+          className="confetti-piece"
+          style={{
+            left: `${p.left}%`,
+            backgroundColor: p.bg,
+            animationDelay: `${p.delay}s`,
+            animationDuration: `${p.duration}s`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Confetti.jsx
+++ b/src/components/Confetti.jsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
 
+const PIECE_COUNT = 80;
+
 export function Confetti({ active, style }) {
   const [pieces, setPieces] = useState([]);
 
   useEffect(() => {
     if (!active) return;
-    const newPieces = Array.from({ length: 40 }).map(() => ({
+    const newPieces = Array.from({ length: PIECE_COUNT }).map(() => ({
       left: Math.random() * 100,
       bg: `hsl(${Math.random() * 360},100%,50%)`,
       delay: Math.random() * 0.5,

--- a/src/components/RoundSummaryOverlay.jsx
+++ b/src/components/RoundSummaryOverlay.jsx
@@ -8,23 +8,22 @@ export function RoundSummaryOverlay({ visible, author, scores, proposals = {} })
 
   return (
     <div className="modal-overlay">
-      <Confetti active={visible} />
       <div className="modal">
         <h2>L'auteur était {author}</h2>
         <h3>Classement</h3>
         <ol style={{ textAlign: 'left' }}>
           {ranking.map(([p, s]) => {
             const guess = proposals[p]?.guess;
-            const marker = guess === author ? '✅' : '❌';
+            const correct = guess === author;
             return (
               <li
                 key={p}
-                style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+                style={{ position: 'relative', padding: '0.5rem 0' }}
               >
-                <span>{marker}</span>
                 <span>
                   {p}: {s}
                 </span>
+                <Confetti active={correct} />
               </li>
             );
           })}

--- a/src/components/RoundSummaryOverlay.jsx
+++ b/src/components/RoundSummaryOverlay.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-
-export function RoundSummaryOverlay({ visible, author, scores }) {
+import { Confetti } from './Confetti';
+export function RoundSummaryOverlay({ visible, author, scores, proposals = {} }) {
   if (!visible) return null;
 
   const ranking = Object.entries(scores)
@@ -8,13 +8,26 @@ export function RoundSummaryOverlay({ visible, author, scores }) {
 
   return (
     <div className="modal-overlay">
+      <Confetti active={visible} />
       <div className="modal">
         <h2>L'auteur était {author}</h2>
         <h3>Classement</h3>
         <ol style={{ textAlign: 'left' }}>
-          {ranking.map(([p, s]) => (
-            <li key={p}>{p}: {s}</li>
-          ))}
+          {ranking.map(([p, s]) => {
+            const guess = proposals[p]?.guess;
+            const marker = guess === author ? '✅' : '❌';
+            return (
+              <li
+                key={p}
+                style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+              >
+                <span>{marker}</span>
+                <span>
+                  {p}: {s}
+                </span>
+              </li>
+            );
+          })}
         </ol>
       </div>
     </div>

--- a/src/hooks/useGameLogic.js
+++ b/src/hooks/useGameLogic.js
@@ -23,6 +23,8 @@ export function useGameLogic(pseudo) {
 
   // **nouveau** : on stocke l’auteur de la manche qui vient de se terminer
   const [lastAuthor, setLastAuthor] = useState(null);
+  // on conserve aussi les propositions de la manche
+  const [lastProposals, setLastProposals] = useState({});
   // paramètres envoyés par le serveur lors du démarrage
   const [gameSettings, setGameSettings] = useState(null);
   const [currentRoom, setCurrentRoom] = useState('');
@@ -86,6 +88,7 @@ export function useGameLogic(pseudo) {
       setMessages([]);
       setAnnouncements([]);
       setLastAuthor(null);  // on réinitialise l’auteur précédent
+      setLastProposals({});
     }
 
     // 4. Message révélé
@@ -102,6 +105,7 @@ export function useGameLogic(pseudo) {
       setTimeLeft(resultDuration);
       setScores(sc);
       setLastAuthor(correctAuthor);  // on conserve l’auteur
+      setLastProposals(proposals);
       const roundAnnouncements = [
         `L'auteur était ${correctAuthor}`,
         ...Object.entries(proposals)
@@ -145,6 +149,7 @@ export function useGameLogic(pseudo) {
       setIsChef(pseudo === chef);
       setGameSettings(null);
       setLastAuthor(null);
+      setLastProposals({});
       setFinalRanking([]);
     }
 
@@ -214,6 +219,7 @@ export function useGameLogic(pseudo) {
     setMessages([]);
     setAnnouncements([]);
     setLastAuthor(null);
+    setLastProposals({});
     setGameSettings(null);
     setCurrentRoom('');
     setFinalRanking([]);
@@ -234,6 +240,7 @@ export function useGameLogic(pseudo) {
     messages,
     announcements,
     lastAuthor,
+    lastProposals,
     gameSettings,
     currentRoom,
     joinRoom,


### PR DESCRIPTION
## Summary
- show confetti animation on round summary overlay
- track last guesses in game logic
- show check or cross emoji by each player depending on guess

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859729de8b88321a8ded78b2f43e4b1