### PR TITLE
Add confetti for correct guesses

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,28 @@
         margin-top: 1rem;
         padding: 0.5rem 1rem;
       }
+
+      .confetti-container {
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        overflow: hidden;
+        z-index: 150;
+      }
+      .confetti-piece {
+        position: absolute;
+        top: -10px;
+        width: 8px;
+        height: 8px;
+        opacity: 0.9;
+        animation-name: confetti-fall;
+        animation-timing-function: linear;
+      }
+      @keyframes confetti-fall {
+        to {
+          transform: translateY(100vh) rotate(720deg);
+        }
+      }
     </style>
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,7 @@ export default function App() {
     messages,
     announcements,
     lastAuthor,
+    lastProposals,
     gameSettings,
     currentRoom,
     joinRoom,
@@ -97,6 +98,7 @@ export default function App() {
         visible={overlayVisible}
         author={lastAuthor}
         scores={scores}
+        proposals={lastProposals}
       />
 
       <GameEndOverlay

--- a/src/components/Confetti.jsx
+++ b/src/components/Confetti.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+
+const PIECE_COUNT = 80;
+
+export function Confetti({ active, style }) {
+  const [pieces, setPieces] = useState([]);
+
+  useEffect(() => {
+    if (!active) return;
+    const newPieces = Array.from({ length: PIECE_COUNT }).map(() => ({
+      left: Math.random() * 100,
+      bg: `hsl(${Math.random() * 360},100%,50%)`,
+      delay: Math.random() * 0.5,
+      duration: 2 + Math.random() * 3,
+    }));
+    setPieces(newPieces);
+  }, [active]);
+
+  if (!active) return null;
+
+  return (
+    <div className="confetti-container" style={style}>
+      {pieces.map((p, i) => (
+        <div
+          key={i}
+          className="confetti-piece"
+          style={{
+            left: `${p.left}%`,
+            backgroundColor: p.bg,
+            animationDelay: `${p.delay}s`,
+            animationDuration: `${p.duration}s`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/RoundSummaryOverlay.jsx
+++ b/src/components/RoundSummaryOverlay.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-
-export function RoundSummaryOverlay({ visible, author, scores }) {
+import { Confetti } from './Confetti';
+export function RoundSummaryOverlay({ visible, author, scores, proposals = {} }) {
   if (!visible) return null;
 
   const ranking = Object.entries(scores)
@@ -12,9 +12,21 @@ export function RoundSummaryOverlay({ visible, author, scores }) {
         <h2>L'auteur était {author}</h2>
         <h3>Classement</h3>
         <ol style={{ textAlign: 'left' }}>
-          {ranking.map(([p, s]) => (
-            <li key={p}>{p}: {s}</li>
-          ))}
+          {ranking.map(([p, s]) => {
+            const guess = proposals[p]?.guess;
+            const correct = guess === author;
+            return (
+              <li
+                key={p}
+                style={{ position: 'relative', padding: '0.5rem 0' }}
+              >
+                <span>
+                  {p}: {s}
+                </span>
+                <Confetti active={correct} />
+              </li>
+            );
+          })}
         </ol>
       </div>
     </div>

--- a/src/hooks/useGameLogic.js
+++ b/src/hooks/useGameLogic.js
@@ -23,6 +23,8 @@ export function useGameLogic(pseudo) {
 
   // **nouveau** : on stocke l’auteur de la manche qui vient de se terminer
   const [lastAuthor, setLastAuthor] = useState(null);
+  // on conserve aussi les propositions de la manche
+  const [lastProposals, setLastProposals] = useState({});
   // paramètres envoyés par le serveur lors du démarrage
   const [gameSettings, setGameSettings] = useState(null);
   const [currentRoom, setCurrentRoom] = useState('');
@@ -86,6 +88,7 @@ export function useGameLogic(pseudo) {
       setMessages([]);
       setAnnouncements([]);
       setLastAuthor(null);  // on réinitialise l’auteur précédent
+      setLastProposals({});
     }
 
     // 4. Message révélé
@@ -102,6 +105,7 @@ export function useGameLogic(pseudo) {
       setTimeLeft(resultDuration);
       setScores(sc);
       setLastAuthor(correctAuthor);  // on conserve l’auteur
+      setLastProposals(proposals);
       const roundAnnouncements = [
         `L'auteur était ${correctAuthor}`,
         ...Object.entries(proposals)
@@ -145,6 +149,7 @@ export function useGameLogic(pseudo) {
       setIsChef(pseudo === chef);
       setGameSettings(null);
       setLastAuthor(null);
+      setLastProposals({});
       setFinalRanking([]);
     }
 
@@ -214,6 +219,7 @@ export function useGameLogic(pseudo) {
     setMessages([]);
     setAnnouncements([]);
     setLastAuthor(null);
+    setLastProposals({});
     setGameSettings(null);
     setCurrentRoom('');
     setFinalRanking([]);
@@ -234,6 +240,7 @@ export function useGameLogic(pseudo) {
     messages,
     announcements,
     lastAuthor,
+    lastProposals,
     gameSettings,
     currentRoom,
     joinRoom,


### PR DESCRIPTION
## Summary
- show confetti next to a player's name only when their guess matches the author
- remove cross and check emojis
- allow `Confetti` component to accept style overrides
- let confetti animation cover the entire screen
- bump confetti pieces from 40 to 80 for a denser effect

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859729de8b88321a8ded78b2f43e4b1