### PR TITLE
Add round points to summary modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,7 @@ export default function App() {
     announcements,
     lastAuthor,
     lastProposals,
+    lastRoundPoints,
     gameSettings,
     currentRoom,
     joinRoom,
@@ -99,6 +100,7 @@ export default function App() {
         author={lastAuthor}
         scores={scores}
         proposals={lastProposals}
+        roundPoints={lastRoundPoints}
       />
 
       <GameEndOverlay

--- a/src/components/RoundSummaryOverlay.jsx
+++ b/src/components/RoundSummaryOverlay.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Confetti } from './Confetti';
-export function RoundSummaryOverlay({ visible, author, scores, proposals = {} }) {
+export function RoundSummaryOverlay({ visible, author, scores, proposals = {}, roundPoints = {} }) {
   if (!visible) return null;
 
   const ranking = Object.entries(scores)
@@ -15,13 +15,14 @@ export function RoundSummaryOverlay({ visible, author, scores, proposals = {} })
           {ranking.map(([p, s]) => {
             const guess = proposals[p]?.guess;
             const correct = guess === author;
+            const points = roundPoints[p] ?? 0;
             return (
               <li
                 key={p}
                 style={{ position: 'relative', padding: '0.5rem 0' }}
               >
                 <span>
-                  {p}: {s}
+                  {correct ? '✅' : '❌'} {p}: {s} (+{points})
                 </span>
                 <Confetti active={correct} />
               </li>

--- a/src/hooks/useGameLogic.js
+++ b/src/hooks/useGameLogic.js
@@ -25,6 +25,8 @@ export function useGameLogic(pseudo) {
   const [lastAuthor, setLastAuthor] = useState(null);
   // on conserve aussi les propositions de la manche
   const [lastProposals, setLastProposals] = useState({});
+  // points gagnés lors de la dernière manche
+  const [lastRoundPoints, setLastRoundPoints] = useState({});
   // paramètres envoyés par le serveur lors du démarrage
   const [gameSettings, setGameSettings] = useState(null);
   const [currentRoom, setCurrentRoom] = useState('');
@@ -89,6 +91,7 @@ export function useGameLogic(pseudo) {
       setAnnouncements([]);
       setLastAuthor(null);  // on réinitialise l’auteur précédent
       setLastProposals({});
+      setLastRoundPoints({});
     }
 
     // 4. Message révélé
@@ -100,12 +103,13 @@ export function useGameLogic(pseudo) {
     }
 
     // 5. Fin de manche : phase "Résultat"
-    function handleRoundEnded({ correctAuthor, proposals, scores: sc, resultDuration }) {
+    function handleRoundEnded({ correctAuthor, proposals, scores: sc, resultDuration, roundPoints }) {
       setPhase('Résultat');
       setTimeLeft(resultDuration);
       setScores(sc);
       setLastAuthor(correctAuthor);  // on conserve l’auteur
       setLastProposals(proposals);
+      setLastRoundPoints(roundPoints || {});
       const roundAnnouncements = [
         `L'auteur était ${correctAuthor}`,
         ...Object.entries(proposals)
@@ -150,6 +154,7 @@ export function useGameLogic(pseudo) {
       setGameSettings(null);
       setLastAuthor(null);
       setLastProposals({});
+      setLastRoundPoints({});
       setFinalRanking([]);
     }
 
@@ -220,6 +225,7 @@ export function useGameLogic(pseudo) {
     setAnnouncements([]);
     setLastAuthor(null);
     setLastProposals({});
+    setLastRoundPoints({});
     setGameSettings(null);
     setCurrentRoom('');
     setFinalRanking([]);
@@ -241,6 +247,7 @@ export function useGameLogic(pseudo) {
     announcements,
     lastAuthor,
     lastProposals,
+    lastRoundPoints,
     gameSettings,
     currentRoom,
     joinRoom,


### PR DESCRIPTION
## Summary
- show whether each guess was correct in the round summary
- keep track of points earned in the last round
- pass these points to the summary overlay

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859908ea19c8321bb7093f9705058bf