### PR TITLE
Add quit button with confirmation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,6 +68,17 @@ export default function App() {
         {gameStarted ? "Devine l'auteur" : `Room #${currentRoom}`}
       </h1>
 
+      <button
+        onClick={() => {
+          if (window.confirm("Quitter la partie ?")) {
+            leaveRoom();
+          }
+        }}
+        style={{ position: 'absolute', top: '1rem', right: '1rem' }}
+      >
+        Quitter
+      </button>
+
       <GameHeader
         roundNumber={roundNumber}
         phase={phase}


### PR DESCRIPTION
## Summary
- add a Quitter button when in a room
- ask for confirmation before leaving and returning to the home screen

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685996fe51088321b22d109ab78a3b58