### PR TITLE
Refresh server list and reload on quit

### DIFF
--- a/src/pages/GamePage.jsx
+++ b/src/pages/GamePage.jsx
@@ -65,6 +65,7 @@ export default function GamePage({ roomCode, pseudo, onLeave }) {
           if (window.confirm('Quitter la partie ?')) {
             leaveRoom();
             if (onLeave) onLeave();
+            window.location.reload();
           }
         }}
         style={{ position: 'absolute', top: '1rem', right: '1rem' }}
@@ -115,6 +116,7 @@ export default function GamePage({ roomCode, pseudo, onLeave }) {
         onQuit={() => {
           leaveRoom();
           if (onLeave) onLeave();
+          window.location.reload();
         }}
       />
 

--- a/src/pages/ServerList.jsx
+++ b/src/pages/ServerList.jsx
@@ -13,7 +13,13 @@ export function ServerList({ pseudo, onJoin, onPseudoChange }) {
       setRooms(rooms);
     }
     socket.on('activeRooms', handleRooms);
-    return () => socket.off('activeRooms', handleRooms);
+    const interval = setInterval(() => {
+      socket.emit('getActiveRooms');
+    }, 5000);
+    return () => {
+      socket.off('activeRooms', handleRooms);
+      clearInterval(interval);
+    };
   }, []);
 
   const createRoom = () => {


### PR DESCRIPTION
## Summary
- reload page when quitting a room
- periodically request server list

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859bbb5077c8321a0d705eec5820d19