### PR TITLE
Add avatars on guess buttons

### DIFF
--- a/src/components/GuessZone.jsx
+++ b/src/components/GuessZone.jsx
@@ -9,7 +9,13 @@ export function GuessZone({ phase, guessOptions, hasGuessed, onGuess }) {
           key={u}
           disabled={hasGuessed}
           onClick={() => onGuess(u)}
+          className="guess-button"
         >
+          <img
+            src={`/assets/pfp/${u}.png`}
+            alt={u}
+            className="guess-img"
+          />
           {u}
         </button>
       ))}

--- a/src/discord.css
+++ b/src/discord.css
@@ -137,3 +137,17 @@ input {
     transform: translateY(100vh) rotate(720deg);
   }
 }
+
+/* ─── Guess buttons ─────────────────────────────────────────────────────── */
+.guess-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.guess-img {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+}


### PR DESCRIPTION
## Summary
- show player profile pictures on each guess button
- style guess buttons so image appears rounded

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c3dfd847083218cddd92c118ef823