### PR TITLE
Ajout avatar auteur dans modal de fin de manche

### DIFF
--- a/src/components/RoundSummaryOverlay.jsx
+++ b/src/components/RoundSummaryOverlay.jsx
@@ -9,6 +9,11 @@ export function RoundSummaryOverlay({ visible, author, scores, proposals = {}, r
   return (
     <div className="modal-overlay">
       <div className="modal">
+        <img
+          src={`src/assets/pfp/${author}.png`}
+          alt={author}
+          className="round-author-img"
+        />
         <h2>L'auteur était {author}</h2>
         <h3>Classement</h3>
         <ol style={{ textAlign: 'left' }}>

--- a/src/discord.css
+++ b/src/discord.css
@@ -200,3 +200,11 @@ input {
   border-radius: 50%;
   object-fit: cover;
 }
+
+.round-author-img {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin-bottom: 1rem;
+}

--- a/src/discord.css
+++ b/src/discord.css
@@ -206,5 +206,4 @@ input {
   height: 64px;
   border-radius: 50%;
   object-fit: cover;
-  margin-bottom: 1rem;
 }


### PR DESCRIPTION
## Summary
- show author's profile picture in the round summary modal
- style new avatar picture

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6861796633e88321944d6a8238c9047c